### PR TITLE
Make OcamlBetterErrors magic-compliant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ setup.data
 setup.log
 
 /tests/**/*actual.txt
+
+node_modules
+.jenga

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ocamlBetterErrors",
+  "version": "0.0.1",
+  "description": "Better errors for ocaml",
+  "dependencies": {
+    "ocamlRe": ">=0.0.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chenglou/BetterErrors.git"
+  },
+  "author": "chenglou"
+}

--- a/src/betterErrorsMain.ml
+++ b/src/betterErrorsMain.ml
@@ -1,5 +1,6 @@
 open BetterErrorsTypes
 open Helpers
+open OcamlRe
 
 (* the compiler output might point to an error that spans across many lines;
 however, instead of indicating from (startRow, startColumn) to (endRow,

--- a/src/betterErrorsParseError.ml
+++ b/src/betterErrorsParseError.ml
@@ -1,5 +1,6 @@
 open BetterErrorsTypes
 open Helpers
+open OcamlRe
 
 (* agnostic extractors, turning err string into proper data structures *)
 (* TODO: don't make these raise error *)

--- a/src/helpers.ml
+++ b/src/helpers.ml
@@ -1,3 +1,5 @@
+open OcamlRe
+
 (* Batteries library substitutes *)
 let listDrop n lst =
   let lst = ref lst in


### PR DESCRIPTION
This relies on the changes I made to jengaboot (see https://github.com/chenglou/jengaboot/pull/6).